### PR TITLE
Rename CLI script to freshservice-mcp in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ name = "Vijay Ragunath"
 email = "vijay.r@effy.co.in"
 
 [project.scripts]
-freshdesk-mcp = "freshdesk_mcp.server:main"
+freshservice-mcp = "freshservice_mcp.server:main"
 


### PR DESCRIPTION
### Summary
Renamed the script defined in `pyproject.toml` from `freshdesk-mcp` to `freshservice-mcp` for clarity and consistency. The project is built specifically for Freshservice, and this change avoids confusion for users and developers.

### Changes Made
- Updated `[project.scripts]` section in `pyproject.toml`:
  ```toml
  [project.scripts]
  freshservice-mcp = "freshservice_mcp.server:main"
  ```
  
Closes #5