### PR TITLE
Version Update: Freshservice MCP Server v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freshservice-mcp"
-version = "0.1.0"
+version = "1.0.0"
 description = "An MCP server for Freshservice"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
This update bumps the version of the Freshservice MCP server to v1.0.0, reflecting enhancements or fixes included in this release. The project remains compatible with Python 3.10 and above.