### PR TITLE
feat: add comprehensive Changes management support to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A powerful MCP (Model Control Protocol) server implementation that seamlessly in
 **This MCP server currently supports operations across a wide range of Freshservice modules**:
 
 -  Tickets
+-  Changes
 -  Conversations
 -  Products
 -  Requesters
@@ -42,10 +43,24 @@ The server provides a comprehensive toolkit for Freshservice operations:
 | `create_ticket` | Create new service tickets | `subject`, `description`, `source`, `priority`, `status`, `email` |
 | `update_ticket` | Update existing tickets | `ticket_id`, `updates` |
 | `delete_ticket` | Remove tickets | `ticket_id` |
-| `search_tickets` | Find tickets matching criteria | `query` |
+| `filter_tickets` | Find tickets matching criteria | `query` |
 | `get_ticket_fields` | Retrieve ticket field definitions | None |
 | `get_tickets` | List all tickets with pagination | `page`, `per_page` |
-| `get_ticket` | Retrieve single ticket details | `ticket_id` |
+| `get_ticket_by_id` | Retrieve single ticket details | `ticket_id` |
+
+### Change Management
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `get_changes` | List all changes with pagination | `page`, `per_page` |
+| `get_change_by_id` | Retrieve single change details | `change_id` |
+| `create_change` | Create new change request | `requester_id`, `subject`, `description`, `priority`, `impact`, `status`, `risk`, `change_type` |
+| `update_change` | Update existing change | `change_id`, `change_fields` |
+| `close_change` | Close change with result explanation | `change_id`, `change_result_explanation` |
+| `delete_change` | Remove change | `change_id` |
+| `filter_changes` | Find changes matching criteria | `query`, `page` |
+| `get_change_tasks` | Get tasks for a change | `change_id` |
+| `create_change_note` | Add note to change | `change_id`, `body` |
 
 ## Getting Started
 
@@ -96,11 +111,21 @@ npx -y @smithery/cli install @effytech/freshservice_mcp --client claude
 
 Once configured, you can ask Claude to perform operations like:
 
+**Tickets:**
 - "Create a new incident ticket with subject 'Network connectivity issue in Marketing department' and description 'Users unable to connect to Wi-Fi in Marketing area', set priority to high"
-- "Update the status of change request #45678 to 'Approved'"
 - "List all critical incidents reported in the last 24 hours"
-- "Show asset details for laptop with asset tag 'LT-2023-087'"
+- "Update ticket #12345 status to resolved"
+
+**Changes:**
 - "Create a change request for scheduled server maintenance next Tuesday at 2 AM"
+- "Update the status of change request #45678 to 'Approved'"
+- "Close change #5092 with result explanation 'Successfully deployed to production. All tests passed.'"
+- "List all pending changes"
+- "Filter changes with status='open' and priority='high'"
+
+**Other Operations:**
+- "Show asset details for laptop with asset tag 'LT-2023-087'"
+- "Create a solution article about password reset procedures"
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,29 @@ The server provides a comprehensive toolkit for Freshservice operations:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `get_changes` | List all changes with pagination | `page`, `per_page` |
+| `get_changes` | List all changes with pagination | `page`, `per_page`, `query` |
+| `filter_changes` | Filter changes with advanced queries | `query`, `page`, `per_page` |
 | `get_change_by_id` | Retrieve single change details | `change_id` |
 | `create_change` | Create new change request | `requester_id`, `subject`, `description`, `priority`, `impact`, `status`, `risk`, `change_type` |
 | `update_change` | Update existing change | `change_id`, `change_fields` |
 | `close_change` | Close change with result explanation | `change_id`, `change_result_explanation` |
 | `delete_change` | Remove change | `change_id` |
-| `filter_changes` | Find changes matching criteria | `query`, `page` |
 | `get_change_tasks` | Get tasks for a change | `change_id` |
 | `create_change_note` | Add note to change | `change_id`, `body` |
+
+#### 🚨 Important: Query Syntax for Filtering
+
+When using `get_changes` or `filter_changes` with the `query` parameter, **the query string must be wrapped in double quotes** for the Freshservice API to work correctly:
+
+✅ **CORRECT**: `"status:3"`, `"approval_status:1 AND status:<6"`  
+❌ **WRONG**: `status:3` (will cause 500 Internal Server Error)
+
+**Common Query Examples:**
+- `"status:3"` - Changes awaiting approval
+- `"approval_status:1"` - Approved changes  
+- `"approval_status:1 AND status:<6"` - Approved changes that are not closed
+- `"planned_start_date:>'2025-07-14'"` - Changes starting after specific date
+- `"status:3 AND priority:1"` - High priority changes awaiting approval
 
 ## Getting Started
 
@@ -121,7 +135,6 @@ Once configured, you can ask Claude to perform operations like:
 - "Update the status of change request #45678 to 'Approved'"
 - "Close change #5092 with result explanation 'Successfully deployed to production. All tests passed.'"
 - "List all pending changes"
-- "Filter changes with status='open' and priority='high'"
 
 **Other Operations:**
 - "Show asset details for laptop with asset tag 'LT-2023-087'"


### PR DESCRIPTION
## Summary
Added complete Changes management functionality to the Freshservice MCP server, including all CRUD operations, filtering, and related endpoints for approvals, notes, tasks, and time entries.

## Key Features Added
### Core Changes API
- `get_changes` - List all changes with pagination and filtering
- `get_change_by_id` - Retrieve single change details
- `create_change` - Create new change request
- `update_change` - Update existing change
- `close_change` - Close change with result explanation
- `delete_change` - Remove change
- `filter_changes` - Find changes matching criteria

### Additional Change Management Endpoints
- **Approvals**: Create, update, cancel approval groups and individual approvals
- **Notes**: Create, view, update, delete notes on changes
- **Tasks**: Full CRUD operations for change tasks
- **Time Entries**: Track time spent on changes
- **Other**: Move changes between workspaces, list change fields

### Query and Filtering Support
- Added comprehensive query parameter support with advanced filtering
- **Critical**: Queries must be wrapped in double quotes (e.g., `"status:3"`)
- Support for complex queries like `"approval_status:1 AND planned_end_date:<'2025-01-14' AND status:<6"`
- Added sorting, pagination, and workspace filtering options

## Documentation Updates
- Added detailed Changes management section to README
- Included query syntax examples and warnings
- Documented all new endpoints with parameters
- Added important notes about double-quote requirements for queries

## Test plan
- [x] Tested all CRUD operations for changes
- [x] Verified query filtering with various query strings
- [x] Confirmed double-quote requirement for API queries
- [x] Tested pagination and sorting functionality
- [x] Verified all endpoints follow existing patterns