### PR TITLE
fix: correct return type for get_ticket_by_id

### DIFF
--- a/src/freshservice_mcp/server.py
+++ b/src/freshservice_mcp/server.py
@@ -388,7 +388,7 @@ async def delete_ticket(ticket_id: int) -> str:
     
 #GET TICKET BY ID  
 @mcp.tool()
-async def get_ticket_by_id(ticket_id:int) -> str:
+async def get_ticket_by_id(ticket_id:int) -> Dict[str, Any]:
     """Get a ticket in Freshservice."""
     url = f"https://{FRESHSERVICE_DOMAIN}/api/v2/tickets/{ticket_id}"
     headers = get_auth_headers()


### PR DESCRIPTION
## Summary
- Fixed incorrect return type annotation for `get_ticket_by_id` function
- Changed from `str` to `Dict[str, Any]` to match the actual return value (`response.json()`)

## Problem
The `get_ticket_by_id` function was annotated to return `str`, but it actually returns the result of `response.json()`, which is a dictionary.

## Solution
Updated the type annotation from `-> str` to `-> Dict[str, Any]` to correctly reflect the return type.