### PR TITLE
fix: wrap filter queries in double quotes (filter_tickets, filter_agents)

### DIFF
--- a/src/freshservice_mcp/server.py
+++ b/src/freshservice_mcp/server.py
@@ -337,15 +337,16 @@ async def update_ticket(ticket_id: int, ticket_fields: Dict[str, Any]) -> Dict[s
 @mcp.tool()
 async def filter_tickets(query: str, page: int = 1, workspace_id: Optional[int] = None) -> Dict[str, Any]:
     """Filter the tickets in Freshservice.
-    
+
     Args:
         query: Filter query string (e.g., "status:2 AND priority:1")
                Note: Some Freshservice endpoints may require queries to be wrapped in double quotes.
                If you get 500 errors, try wrapping your query in double quotes: "your_query_here"
-        page: Page number (default: 1)  
+        page: Page number (default: 1)
         workspace_id: Optional workspace ID filter
     """
-    encoded_query = urllib.parse.quote(query)
+    # Freshservice API requires the query to be wrapped in double quotes
+    encoded_query = urllib.parse.quote(f'"{query}"')
     url = f"https://{FRESHSERVICE_DOMAIN}/api/v2/tickets/filter?query={encoded_query}&page={page}"
     
     if workspace_id is not None:

--- a/src/freshservice_mcp/server.py
+++ b/src/freshservice_mcp/server.py
@@ -2166,10 +2166,12 @@ async def filter_agents(query: str) -> List[Dict[str, Any]]:
     headers = get_auth_headers()
     all_agents = []
     page = 1
+    # Freshservice API requires the query to be wrapped in double quotes
+    encoded_query = urllib.parse.quote(f'"{query}"')
 
     async with httpx.AsyncClient() as client:
         while True:
-            url = f"{base_url}?query={query}&page={page}"
+            url = f"{base_url}?query={encoded_query}&page={page}"
             response = await client.get(url, headers=headers)
             response.raise_for_status()
 

--- a/tests/test-fs-mcp.py
+++ b/tests/test-fs-mcp.py
@@ -310,8 +310,9 @@ async def test_get_solution_article():
     print(result)
 
 async def test_filter_tickets():
-    query = '"priority:3"'   
-    result = await filter_tickets(query) 
+    # Quotes are now automatically added by the function
+    query = "priority:3"
+    result = await filter_tickets(query)
     print(result)
 
 async def test_filter_requesters():
@@ -322,7 +323,9 @@ async def test_filter_requesters():
     print(result)
         
 async def test_filter_agents():
-    query = "department_id:123 AND created_at:>'2024-01-01'"
+    # Quotes are now automatically added by the function
+    # Note: use valid filter fields like first_name, email, etc.
+    query = "first_name:John"
     agents = await filter_agents(query)
     print(agents)
 


### PR DESCRIPTION
## Problem

The `filter_tickets` and `filter_agents` functions return 400 Bad Request errors because the Freshservice API requires filter queries to be wrapped in double quotes.

### filter_tickets

The current docstring suggests users wrap their queries in quotes manually:
```
Note: Some Freshservice endpoints may require queries to be wrapped in double quotes.
If you get 500 errors, try wrapping your query in double quotes: "your_query_here"
```

However, this doesn't work through the MCP interface because:
1. When users pass `"status:2"` through the MCP tool, the quotes are consumed by JSON serialization
2. The user experience is poor - the API should handle this automatically

### filter_agents

This function had two bugs:
1. No URL encoding of the query parameter at all
2. No double-quote wrapping

## Solution

Wrap queries in double quotes at the code level before URL encoding:

**filter_tickets (line 348):**
```python
# Before (broken):
encoded_query = urllib.parse.quote(query)

# After (working):
encoded_query = urllib.parse.quote(f'"{query}"')
```

**filter_agents (line 2170):**
```python
# Before (broken - no encoding at all):
url = f"{base_url}?query={query}&page={page}"

# After (working):
encoded_query = urllib.parse.quote(f'"{query}"')
url = f"{base_url}?query={encoded_query}&page={page}"
```

## Test Updates

Updated the test file to work with the new automatic quote wrapping:
- `test_filter_tickets`: Removed manual quotes from query
- `test_filter_agents`: Fixed to use valid filter field (`first_name` instead of `department_id`)

## Testing

Verified locally:
- `filter_tickets('agent_id:34000962672')` - returns 15 tickets
- `filter_tickets('priority:3')` - returns 6 tickets  
- `filter_agents('first_name:Drew')` - returns 1 agent

## Related Issue

See #21 for full details