### PR TITLE
fix: resolve MCP output schema validation error for get_ticket_by_id

### DIFF
--- a/src/freshservice_mcp/server.py
+++ b/src/freshservice_mcp/server.py
@@ -388,7 +388,7 @@ async def delete_ticket(ticket_id: int) -> str:
                 return "Error: Unexpected response format"
     
 #GET TICKET BY ID  
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_ticket_by_id(ticket_id:int) -> Dict[str, Any]:
     """Get a ticket in Freshservice."""
     url = f"https://{FRESHSERVICE_DOMAIN}/api/v2/tickets/{ticket_id}"


### PR DESCRIPTION
## Problem

The `get_ticket_by_id` tool fails with a Pydantic validation error when called via MCP clients:

```
1 validation error for get_ticket_by_idOutput
result
  Input should be a valid string [type=string_type, input_value={'ticket': {...}}, input_type=dict]
```

## Root Cause

The MCP SDK automatically generates an output schema from the function's return type annotation (`-> Dict[str, Any]`). Due to how generic types are handled, the SDK creates a schema expecting `result: str` instead of properly handling the dictionary return type.

When the tool successfully fetches ticket data from the Freshservice API and returns a `dict`, the output validation fails because the schema expects a string.

## Solution

Add `structured_output=False` to the `@mcp.tool()` decorator. This tells the MCP SDK to skip output schema validation and return the content directly, which is the appropriate behavior for tools returning dynamic API responses.

```python
@mcp.tool(structured_output=False)
async def get_ticket_by_id(ticket_id: int) -> Dict[str, Any]:
```

## Testing

- Verified the fix resolves the validation error
- Tool now successfully returns ticket data to MCP clients
- No breaking changes to the API response format

## References

- [MCP Python SDK - Structured Output](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)
- Related issue pattern documented in MCP SDK