### PR TITLE
Fix get_ticket_by_id output validation

### DIFF
--- a/src/freshservice_mcp/server.py
+++ b/src/freshservice_mcp/server.py
@@ -388,7 +388,7 @@ async def delete_ticket(ticket_id: int) -> str:
                 return "Error: Unexpected response format"
     
 #GET TICKET BY ID  
-@mcp.tool(structured_output=False)
+@mcp.tool()
 async def get_ticket_by_id(ticket_id:int) -> Dict[str, Any]:
     """Get a ticket in Freshservice."""
     url = f"https://{FRESHSERVICE_DOMAIN}/api/v2/tickets/{ticket_id}"


### PR DESCRIPTION
## Summary

- Restores structured output for `get_ticket_by_id` by registering it with the default `@mcp.tool()` decorator.
- Fixes validation failures when Freshservice returns the ticket JSON object.

## Root cause

`get_ticket_by_id` returns `response.json()` as a dictionary, but it was registered with
`structured_output=False`, which causes the MCP runtime to validate the result as unstructured text.

## Validation

- Ran `python -m py_compile src/freshservice_mcp/server.py` successfully.